### PR TITLE
Dhdl bugfixes python3

### DIFF
--- a/src/pmx/analysis.py
+++ b/src/pmx/analysis.py
@@ -78,7 +78,7 @@ def integrate_dgdl(fn, ndata=-1, lambda0=0, invert_values=False, sigmoid=0.0):
     # check lambda0 is either 0 or 1
     assert lambda0 in [0, 1]
 
-    lines = open(fn).readlines()
+    lines = open(fn, encoding="ISO-8859-1").readlines()
     if not lines:
         return None, None
 
@@ -342,7 +342,7 @@ def plot_work_dist(wf, wr, fname='Wdist.png', nbins=20, dG=None, dGerr=None,
 
 def _check_dgdl(fn, lambda0, verbose=True):
     '''Prints some info about a dgdl.xvg file.'''
-    lines = open(fn).readlines()
+    lines = open(fn, encoding="ISO-8859-1").readlines()
     if not lines:
         return None
     r = []

--- a/src/pmx/analysis.py
+++ b/src/pmx/analysis.py
@@ -304,9 +304,9 @@ def plot_work_dist(wf, wr, fname='Wdist.png', nbins=20, dG=None, dGerr=None,
         val.set_lw(2)
     plt.subplot(1, 2, 2)
     plt.hist(wf, bins=nbins, orientation='horizontal', facecolor='green',
-             alpha=.75, normed=True)
+             alpha=.75, density=True)
     plt.hist(wr, bins=nbins, orientation='horizontal', facecolor='blue',
-             alpha=.75, normed=True)
+             alpha=.75, density=True)
 
     x = np.arange(mini, maxi, .5)
 

--- a/src/pmx/analysis.py
+++ b/src/pmx/analysis.py
@@ -80,6 +80,7 @@ def read_dgdl_files(lst, lambda0=0, invert_values=False, verbose=True,\
     #Everything before is too short.
     good=False
     idx, t_list=find_longest_dgdl_file(lst) 
+    last_t=t_list[idx]
     first_w=0
     ndata=0
     while(not good and idx<len(lst)):

--- a/src/pmx/scripts/analyze_dhdl.py
+++ b/src/pmx/scripts/analyze_dhdl.py
@@ -12,7 +12,7 @@ import numpy as np
 import pickle
 import argparse
 import warnings
-from .cli import check_unknown_cmd
+from cli import check_unknown_cmd
 
 # Constants
 kb = 0.00831447215   # kJ/(K*mol)

--- a/src/pmx/scripts/analyze_dhdl.py
+++ b/src/pmx/scripts/analyze_dhdl.py
@@ -608,6 +608,9 @@ def main(args):
                                                                                  p=prec, u=units), quiet=quiet)
 
     _tee(out, ' ========================================================', quiet=quiet)
+    
+    #close the outputfile, forsing a fush to disk, so that the unit test can read it properly
+    out.close();
 
     # -----------------------
     # plot work distributions

--- a/src/pmx/scripts/analyze_dhdl.py
+++ b/src/pmx/scripts/analyze_dhdl.py
@@ -12,7 +12,7 @@ import numpy as np
 import pickle
 import argparse
 import warnings
-from cli import check_unknown_cmd
+from pmx.scripts.cli import check_unknown_cmd
 
 # Constants
 kb = 0.00831447215   # kJ/(K*mol)

--- a/src/pmx/scripts/analyze_dhdl.py
+++ b/src/pmx/scripts/analyze_dhdl.py
@@ -609,7 +609,7 @@ def main(args):
 
     _tee(out, ' ========================================================', quiet=quiet)
     
-    #close the outputfile, forsing a fush to disk, so that the unit test can read it properly
+    #close the outputfile, forcing a flush to disk, so that the unit test can read it properly
     out.close();
 
     # -----------------------

--- a/src/pmx/scripts/analyze_dhdl.py
+++ b/src/pmx/scripts/analyze_dhdl.py
@@ -610,7 +610,7 @@ def main(args):
     _tee(out, ' ========================================================', quiet=quiet)
     
     #close the outputfile, forcing a flush to disk, so that the unit test can read it properly
-    out.close();
+    out.close()
 
     # -----------------------
     # plot work distributions

--- a/src/pmx/scripts/generate_hybrid_residue.py
+++ b/src/pmx/scripts/generate_hybrid_residue.py
@@ -12,7 +12,7 @@ from pmx.geometry import Rotation
 from pmx.ffparser import RTPParser, NBParser
 from pmx.parser import kickOutComments, readSection, parseList
 from pmx.utils import list2file, get_pmxdata, natural_sort, initialise_logger
-from .cli import check_unknown_cmd
+from cli import check_unknown_cmd
 
 
 # ==============================================================================

--- a/src/pmx/scripts/generate_hybrid_residue.py
+++ b/src/pmx/scripts/generate_hybrid_residue.py
@@ -12,7 +12,7 @@ from pmx.geometry import Rotation
 from pmx.ffparser import RTPParser, NBParser
 from pmx.parser import kickOutComments, readSection, parseList
 from pmx.utils import list2file, get_pmxdata, natural_sort, initialise_logger
-from cli import check_unknown_cmd
+from pmx.scripts.cli import check_unknown_cmd
 
 
 # ==============================================================================

--- a/src/pmx/scripts/generate_hybrid_topology.py
+++ b/src/pmx/scripts/generate_hybrid_topology.py
@@ -35,7 +35,7 @@ from pmx.forcefield import Topology
 from pmx.utils import ff_selection
 from pmx.utils import multiple_replace
 from pmx.alchemy import gen_hybrid_top, write_split_top
-from .cli import check_unknown_cmd
+from cli import check_unknown_cmd
 
 
 def _change_outfile_format(filename, ext):

--- a/src/pmx/scripts/generate_hybrid_topology.py
+++ b/src/pmx/scripts/generate_hybrid_topology.py
@@ -35,7 +35,7 @@ from pmx.forcefield import Topology
 from pmx.utils import ff_selection
 from pmx.utils import multiple_replace
 from pmx.alchemy import gen_hybrid_top, write_split_top
-from cli import check_unknown_cmd
+from pmx.scripts.cli import check_unknown_cmd
 
 
 def _change_outfile_format(filename, ext):

--- a/src/pmx/scripts/make_double_box.py
+++ b/src/pmx/scripts/make_double_box.py
@@ -2,7 +2,7 @@
 
 import argparse
 from pmx.model import Model, double_box
-from .cli import check_unknown_cmd
+from cli import check_unknown_cmd
 
 
 def parse_options():

--- a/src/pmx/scripts/make_double_box.py
+++ b/src/pmx/scripts/make_double_box.py
@@ -2,7 +2,7 @@
 
 import argparse
 from pmx.model import Model, double_box
-from cli import check_unknown_cmd
+from pmx.scripts.cli import check_unknown_cmd
 
 
 def parse_options():

--- a/src/pmx/scripts/mutate.py
+++ b/src/pmx/scripts/mutate.py
@@ -41,7 +41,7 @@ from pmx.model import Model
 from pmx.parser import read_and_format
 from pmx.utils import get_ff_path, ff_selection
 from pmx.alchemy import mutate
-from cli import check_unknown_cmd
+from pmx.scripts.cli import check_unknown_cmd
 
 # resinfo
 dna_one_letter = {'A': 'adenosine',

--- a/src/pmx/scripts/mutate.py
+++ b/src/pmx/scripts/mutate.py
@@ -41,7 +41,7 @@ from pmx.model import Model
 from pmx.parser import read_and_format
 from pmx.utils import get_ff_path, ff_selection
 from pmx.alchemy import mutate
-from .cli import check_unknown_cmd
+from cli import check_unknown_cmd
 
 # resinfo
 dna_one_letter = {'A': 'adenosine',

--- a/src/pmx/scripts/setup_abfe.py
+++ b/src/pmx/scripts/setup_abfe.py
@@ -10,7 +10,7 @@ from pmx.forcefield import Topology, merge_atomtypes
 from pmx import gmx
 from copy import deepcopy
 from time import sleep
-from .cli import check_unknown_cmd
+from cli import check_unknown_cmd
 
 
 # TODO: build folder structure and mdp files for equil or nonequil calcs?

--- a/src/pmx/scripts/setup_abfe.py
+++ b/src/pmx/scripts/setup_abfe.py
@@ -10,7 +10,7 @@ from pmx.forcefield import Topology, merge_atomtypes
 from pmx import gmx
 from copy import deepcopy
 from time import sleep
-from cli import check_unknown_cmd
+from pmx.scripts.cli import check_unknown_cmd
 
 
 # TODO: build folder structure and mdp files for equil or nonequil calcs?

--- a/tests/test_dhdl.py
+++ b/tests/test_dhdl.py
@@ -10,16 +10,16 @@ import sys
 
 def test_dhdl(tmpdir):
     #make fake dHdl files in a temp directory
-    trjlen=51;
-    dif=3.0;
+    trjlen=51
+    dif=3.0
     W_scale=100.0
-    dG=100.0;
-    noise_scale=10.0;
-    nruns=80;
+    dG=100.0
+    noise_scale=10.0
+    nruns=80
     l=np.linspace(0., 1., num=trjlen, endpoint=True)
     signal=(1/(1+np.exp((-l+0.5)*10))-0.5)*W_scale + dG
     
-    np.random.seed(123456); #force reproducible random numbers
+    np.random.seed(123456) #force reproducible random numbers
     
     fns_f=[]
     fns_b=[]
@@ -50,8 +50,8 @@ def test_dhdl(tmpdir):
     os.chdir(orig_dir)   #reset cwd
 
     #read results
-    bar=-1;
-    barerr=-1;
+    bar=-1
+    barerr=-1
     print("#"*40)
     with open(str(tmpdir)+"/results.txt","rb") as fp:
         lines = fp.readlines()
@@ -67,5 +67,5 @@ def test_dhdl(tmpdir):
                 print(s)
                 barerr=float(s[-2])
     
-    assert_almost_equal(bar, dG*0.98, decimal=2);
-    assert_almost_equal(barerr, 0.17, decimal=2);
+    assert_almost_equal(bar, dG*0.98, decimal=2)
+    assert_almost_equal(barerr, 0.17, decimal=2)

--- a/tests/test_dhdl.py
+++ b/tests/test_dhdl.py
@@ -28,7 +28,7 @@ def test_dhdl(tmpdir):
         b=signal - 0.5*dif + np.random.normal(loc=0.0, scale=noise_scale, size=signal.shape)
         
         dataf=np.transpose(np.vstack((l,f)))
-        datab=np.transpose(np.vstack((np.flip(l),np.flip(b))))
+        datab=np.transpose(np.vstack((l,np.flip(b)))) # don't flip l. it's used as time here, not lambda value
         fh_f=tmpdir.join("test_temp_f%d.xvg"%i)
         fh_b=tmpdir.join("test_temp_b%d.xvg"%i)
         np.savetxt(fh_f, dataf, fmt='%16.8f')

--- a/tests/test_dhdl.py
+++ b/tests/test_dhdl.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+import pytest
+from pmx.scripts.analyze_dhdl import entry_point
+import os
+import numpy as np
+from numpy.random import normal,seed
+from numpy.testing import assert_almost_equal
+import sys
+
+
+def test_dhdl(tmpdir):
+    #make fake dHdl files in a temp directory
+    trjlen=51;
+    dif=3.0;
+    W_scale=100.0
+    dG=100.0;
+    noise_scale=10.0;
+    nruns=80;
+    l=np.linspace(0., 1., num=trjlen, endpoint=True)
+    signal=(1/(1+np.exp((-l+0.5)*10))-0.5)*W_scale + dG
+    
+    np.random.seed(123456); #force reproducible random numbers
+    
+    fns_f=[]
+    fns_b=[]
+    for i in range(nruns):
+        f=signal + 0.5*dif + np.random.normal(loc=0.0, scale=noise_scale, size=signal.shape)
+        b=signal - 0.5*dif + np.random.normal(loc=0.0, scale=noise_scale, size=signal.shape)
+        
+        dataf=np.transpose(np.vstack((l,f)))
+        datab=np.transpose(np.vstack((np.flip(l),np.flip(b))))
+        fh_f=tmpdir.join("test_temp_f%d.xvg"%i)
+        fh_b=tmpdir.join("test_temp_b%d.xvg"%i)
+        np.savetxt(fh_f, dataf, fmt='%16.8f')
+        np.savetxt(fh_b, datab, fmt='%16.8f')
+        
+        fns_f.append(str(fh_f))
+        fns_b.append(str(fh_b))
+        
+    #run analysis on our fake files
+    orig_argv = sys.argv
+    orig_dir = os.getcwd()
+    os.chdir(tmpdir)
+    sys.argv = [['analyze_dhdl.py'],\
+                ['-fA'], [x for x in fns_f],\
+                ['-fB'], [x for x in fns_b]]
+    sys.argv = [item for sublist in sys.argv for item in sublist]
+    entry_point()
+    sys.argv = orig_argv #reset argv
+    os.chdir(orig_dir)   #reset cwd
+
+    #read results
+    bar=-1;
+    barerr=-1;
+    print("#"*40)
+    with open(str(tmpdir)+"/results.txt","rb") as fp:
+        lines = fp.readlines()
+        for line in lines:
+            line=line.decode()
+            print(line)
+            if("BAR: dG =" in line):
+                s=line.split()
+                print(s)
+                bar=float(s[-2])
+            elif("BAR: Std Err (analytical) =" in line):
+                s=line.split()
+                print(s)
+                barerr=float(s[-2])
+    
+    assert_almost_equal(bar, dG*0.98, decimal=2);
+    assert_almost_equal(barerr, 0.17, decimal=2);

--- a/tests/test_dhdl.py
+++ b/tests/test_dhdl.py
@@ -69,3 +69,4 @@ def test_dhdl(tmpdir):
     
     assert_almost_equal(bar, dG*0.98, decimal=2)
     assert_almost_equal(barerr, 0.17, decimal=2)
+    


### PR DESCRIPTION
Some bug fixes for analyzing dHdl files. Especially useful when a lot of the non-equilibrium simulations crash producing corrupt dHdl files. Also added a unit test for the relevant analysis script.