### PR TITLE
Fix issue when the input line is empty

### DIFF
--- a/src/pmx/ligand_alchemy.py
+++ b/src/pmx/ligand_alchemy.py
@@ -2800,7 +2800,8 @@ class _FFfile:
         toSkip = "atomtypes"
         for line in l:
             if toSkip not in line:
-                self.atoms.append(_FFatom(line.split()))
+                if line.split():
+                    self.atoms.append(_FFatom(line.split()))
 
 def _get_FF_atoms( ffs ):
     atoms = {}


### PR DESCRIPTION
When the input is [], this line is failed. Adding this check to make sure the line can be splitted