### PR TITLE
Fix output format issue

### DIFF
--- a/src/pmx/ligand_alchemy.py
+++ b/src/pmx/ligand_alchemy.py
@@ -2823,7 +2823,7 @@ def _write_FF_file(atoms,file):
     fp.write('[ atomtypes ]\n')
     for atype in atoms.keys():
         at = atoms[atype]
-        fp.write('      %s      %s      %s      %s      %s      %s\n' % (at.type,at.sigmaA,at.epsA,at.A,at.sigmaB,at.epsB) )
+        fp.write('%s      %s      %s      %s      %s      %s\n' % (at.type,at.sigmaA,at.epsA,at.A,at.sigmaB,at.epsB) )
         
 def _merge_FF_files( fnameOut, ffsIn=[] ):
     atoms = _get_FF_atoms( ffsIn )


### PR DESCRIPTION
Delete the spaces to make sure the output is aligned with latest gromacs.

Before:
```
[ atomtypes ]
      ;name      bond_type      mass      charge      ptype      sigma
      nc      nc      0.00000      0.00000      A      3.38417e-01
      cc      cc      0.00000      0.00000      A      3.31521e-01
```


After:
```
[ atomtypes ]
;name      bond_type      mass      charge      ptype      sigma
nc      nc      0.00000      0.00000      A      3.38417e-01
cc      cc      0.00000      0.00000      A      3.31521e-01
```