### PR TITLE
FIX: old GIT (<1.7.2) does not know about `--count` flag

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -1105,9 +1105,9 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
+        out, rc = run_command(GITS, ["rev-list", "HEAD", "--left-right"],
                                     cwd=root)
-        pieces["distance"] = int(count_out)  # total number of commits
+        pieces["distance"] = len(out.split())  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
     date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],


### PR DESCRIPTION
See https://github.com/python-versioneer/python-versioneer/pull/306

`--count` flag comes from git v1.7.2 with commit https://github.com/git/git/commit/f69c501832ecd6880602c55565508e70c3a013d5