### PR TITLE
Changed scipy simps import due to API change

### DIFF
--- a/src/pmx/analysis.py
+++ b/src/pmx/analysis.py
@@ -3,7 +3,10 @@ import numpy as np
 import subprocess
 import os
 from os import path
-from scipy.integrate import simps
+try:
+    from scipy.integrate import simps
+except ImportError:
+    from scipy.integrate import simpson as simps
 from matplotlib import pyplot as plt
 from copy import deepcopy
 from scipy.special import erf


### PR DESCRIPTION
No [`simps`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.simpson.html) method in new `scipy` versions