### PR TITLE
Fix Cl and Br atom issue in atomMapping

### DIFF
--- a/src/pmx/ligand_alchemy.py
+++ b/src/pmx/ligand_alchemy.py
@@ -92,12 +92,12 @@ def writeFormatPDB(fname,m,title="",nr=1,bStrict=False):
     for atom in m.atoms:
         foo = cp.deepcopy(atom)
         # chlorine
-        if( 'CL' in atom.name or 'Cl' in atom.name or 'cl' in atom.name ):
-            foo.name = "CL"#+"  "
+        if atom.name.upper().startswith("CL"):
+            foo.name = ("Cl" + atom.name[2:])[:atNameLen]
             print(foo,file=fp)
         # bromine
-        elif( 'BR' in atom.name or 'Br' in atom.name or 'br' in atom.name ):
-            foo.name = "BR"#+"  "
+        elif atom.name.upper().startswith("BR"):
+            foo.name = ("Br" + atom.name[2:])[:atNameLen]
             print(foo,file=fp)
         elif( len(atom.name) > atNameLen): # too long atom name
             foo = cp.deepcopy(atom)


### PR DESCRIPTION
The Cl atom is incorrectly converted to C by "pmx atomMapping" due to a misimplementation in the writeFormatPDB method.
As a result, the script below should output two "CCl", but it outputs two "CC" instead. Br atom also has the same problem.
This PR fixes the issue.

```bash
python -c "from rdkit.Chem.AllChem import *; m = MolFromSmiles('ClC'); EmbedMolecule(m); MolToPDBFile(m, 'm1.pdb')"
python -c "from rdkit.Chem.AllChem import *; m = MolFromSmiles('ClC'); EmbedMolecule(m); MolToPDBFile(m, 'm2.pdb')"
pmx atomMapping -i1 m1.pdb -i2 m2.pdb -opdb1 pdb1.pdb -opdb2 pdb2.pdb
python -c "from rdkit.Chem.AllChem import *; m = MolFromPDBFile('pdb1.pdb'); print(MolToSmiles(m));"
python -c "from rdkit.Chem.AllChem import *; m = MolFromPDBFile('pdb2.pdb'); print(MolToSmiles(m));"
```
